### PR TITLE
Add Keycloak client configuration for authentication

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.126",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
+    "keycloak-js": "^26.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
@@ -40,5 +41,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/keycloak-js": "^2.5.4"
   }
 }

--- a/client/src/keycloakClient/keycloakInitClient.ts
+++ b/client/src/keycloakClient/keycloakInitClient.ts
@@ -1,0 +1,10 @@
+
+import Keycloak from 'keycloak-js';
+
+const keycloak = Keycloak({
+    url: 'http://localhost:8080/auth',
+    realm: 'Messenger',
+    clientId: 'messenger-client',
+});
+
+export default keycloak;

--- a/server/package.json
+++ b/server/package.json
@@ -17,8 +17,10 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-session": "^1.18.1",
+    "express-validator": "^7.2.1",
     "keycloak-connect": "^26.1.1",
-    "pg": "^8.16.0"
+    "pg": "^8.16.0",
+    "socket.io": "^4.8.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Summary by Sourcery

Set up Keycloak-based authentication by installing and configuring keycloak-js on the client side and updating server dependencies for input validation and real-time communication

New Features:
- Add Keycloak client initialization module in the frontend for authentication
- Add express-validator to the server for request validation
- Add socket.io to the server for real-time communication

Enhancements:
- Add keycloak-js and its TypeScript definitions to client dependencies