### PR TITLE
Migrate from Create React App to Vite build system

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,46 +2,22 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
   "dependencies": {
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^27.5.2",
-    "@types/react": "^19.1.6",
-    "@types/react-dom": "^19.1.5",
     "keycloak-js": "^26.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "socket.io-client": "^4.8.1",
-    "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
-    "@types/keycloak-js": "^2.5.4"
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^4.6.0",
+    "typescript": "^4.9.5",
+    "vite": "^4.5.14"
   }
 }

--- a/client/src/hooks/useKeycloakAuth.ts
+++ b/client/src/hooks/useKeycloakAuth.ts
@@ -25,7 +25,6 @@ export function useKeycloakAuth(): KeycloakAuth {
             setAuthenticated(auth);
             // если авторизация успешна, получение имени пользователя
             if (auth) {
-                // @ts-expect-error
                 setUser(keycloak.tokenParsed?.preferred_username);
             }
         }).error((err: any) => {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3001,
+    open: true,
+  },
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,14 +28,14 @@ app.use('/messages', keycloak.protect() as any, messagesRouter);
 app.get('/protected', keycloak.protect() as any, (req, res) => {
     res.json({
         message: 'Это защищенный маршрут',
-        user: (req as any).kauth.grant.access_token.content.preferred_username,
+        user: (req as any)?.kauth?.grant?.access_token?.content?.preferred_username
     });
 });
 
 app.get('/login', keycloak.protect() as any, (req, res) => {
     res.json({
         message: 'Вы успешно авторизованы!',
-        user: (req as any).kauth.grant.access_token.content.preferred_username,
+        user: (req as any)?.kauth?.grant?.access_token?.content?.preferred_username,
     });
 });
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate the client build from Create React App to Vite, update related scripts and dependencies, add Vite config, and improve Keycloak data handling with optional chaining.

Enhancements:
- Replace CRA scripts and dependencies with Vite scripts, plugins, and devDependencies
- Add vite.config.ts with React plugin, port/open server settings, and source alias
- Remove CRA-specific ESLint config, browserslist, and testing libraries from package.json
- Use optional chaining for Keycloak data in server endpoint and remove unnecessary ts-expect-error in the client hook