### PR TITLE
Унифицировать userId assignment в socketAuthMiddleware

### DIFF
--- a/client/src/components/messages/MessageList.tsx
+++ b/client/src/components/messages/MessageList.tsx
@@ -37,11 +37,15 @@ const MessageList: React.FC<MessageListProps> = ({ messages, users }) => {
       console.warn('Users array is undefined');
       return senderId;
     }
-    // Сначала ищем по id
+    // Сначала ищем по id строго
     let user = users.find(u => u.id === senderId);
     if (!user) {
       // Если не нашли, ищем по username
       user = users.find(u => u.username === senderId);
+    }
+    // Если user не найден, попробуем найти по id в нижнем регистре (на случай несоответствия регистра)
+    if (!user) {
+      user = users.find(u => u.id.toLowerCase() === senderId.toLowerCase());
     }
     console.log('Found user:', user);
     return user ? user.username : senderId;

--- a/server/src/middleware/socketAuthMiddleware.ts
+++ b/server/src/middleware/socketAuthMiddleware.ts
@@ -28,8 +28,8 @@ export const socketAuthMiddleware =
         if (!tokenContent){
             return next(new Error(" Ошибка авторизации: неверный токен"))
         }
-        // Устанавливаем userId для совместимости с REST API
-        socket.userId = tokenContent.preferred_username || tokenContent.sub;
+        // Устанавливаем userId как UUID (sub) для унификации
+        socket.userId = tokenContent.sub || tokenContent.preferred_username;
            // Сохраняем декодированный токен для совместимости с userSocketHandler
            (socket as any).decoded_token = tokenContent
            console.log(`WebSocket авторизация успешна для пользователя ${socket.userId}`)

--- a/server/src/webSocket/messageSocketHandler.ts
+++ b/server/src/webSocket/messageSocketHandler.ts
@@ -2,57 +2,80 @@ import { Server as SocketIOServer } from "socket.io";
 import { AuthenticatedSocket } from "../middleware/socketAuthMiddleware";
 import { clearUserMessages, saveMessage } from "../utilsComponents/messageService";
 
+const userSocketMap = new Map<string, string>(); // userId -> socketId
+
 export function registerMessageSocketHandler(io: SocketIOServer) {
   io.on("connection", (socket: AuthenticatedSocket) => {
-    
+    const userId = socket.userId;
+    if (userId) {
+      userSocketMap.set(userId, socket.id);
+    }
+
+    socket.on("disconnect", () => {
+      if (userId) {
+        userSocketMap.delete(userId);
+      }
+    });
+
     socket.on("clearMessages", async () => {
       try {
-        const userId = socket.userId;
-        
         if (!userId) {
           throw new Error("ID пользователя отсутствует");
         }
 
         console.log(`Очистка сообщений для пользователя: ${userId}`);
-        
+
         const deletedCount = await clearUserMessages(userId);
-        
-        // Отправляем подтверждение клиенту
-        socket.emit("messagesCleared", { 
-          success: true, 
-          count: deletedCount 
+
+        socket.emit("messagesCleared", {
+          success: true,
+          count: deletedCount,
         });
-        
+
         console.log(`Удалено ${deletedCount} сообщений для пользователя ${userId}`);
       } catch (error) {
         console.error("Ошибка при очистке сообщений:", error);
-        socket.emit("clearMessages_error", "Не удалось очистить сообщения");
+        socket.emit( "Не удалось очистить сообщения");
       }
     });
 
-    // Добавляем обработчик отправки сообщений
-    socket.on("sendMessage", async (messagePayload: { recipientId: string; content: string }) => {
-      try {
-        const senderId = socket.userId;
-        if (!senderId) {
-          throw new Error("ID отправителя отсутствует");
+    socket.on(
+      "sendMessage",
+      async (messagePayload: { recipientId: string; content: string }) => {
+        try {
+          if (!userId) {
+            throw new Error("ID отправителя отсутствует");
+          }
+          const { recipientId, content } = messagePayload;
+          if (!recipientId || !content) {
+            throw new Error("Получатель и содержимое сообщения обязательны");
+          }
+
+          console.log("Текущий userSocketMap:", Array.from(userSocketMap.entries()));
+          console.log("Полученный recipientId:", recipientId);
+
+          // Сохраняем сообщение в базе
+          const savedMessage = await saveMessage(userId, recipientId, content);
+
+          // Отправляем новое сообщение отправителю
+          socket.emit("newMessage", savedMessage);
+
+          // Отправляем новое сообщение получателю, если он онлайн
+          const recipientSocketId = userSocketMap.get(recipientId);
+          if (recipientSocketId) {
+            io.to(recipientSocketId).emit("newMessage", savedMessage);
+          } else {
+            console.log(`SocketId для получателя ${recipientId} не найден`);
+          }
+
+          console.log(
+            `Новое сообщение от ${userId} к ${recipientId}: ${content}`
+          );
+        } catch (error) {
+          console.error("Ошибка при отправке сообщения:", error);
+          socket.emit("sendMessage_error", "Не удалось отправить сообщение");
         }
-        const { recipientId, content } = messagePayload;
-        if (!recipientId || !content) {
-          throw new Error("Получатель и содержимое сообщения обязательны");
-        }
-
-        // Сохраняем сообщение в базе
-        const savedMessage = await saveMessage(senderId, recipientId, content);
-
-        // Отправляем новое сообщение всем подключенным клиентам
-        io.emit("newMessage", savedMessage);
-
-        console.log(`Новое сообщение от ${senderId} к ${recipientId}: ${content}`);
-      } catch (error) {
-        console.error("Ошибка при отправке сообщения:", error);
-        socket.emit("sendMessage_error", "Не удалось отправить сообщение");
       }
-    });
+    );
   });
 }


### PR DESCRIPTION
## Summary by Sourcery

Unify userId assignment in WebSocket auth and revamp message routing to support private messaging with receiver tracking, updating the client to normalize and filter messages per chat partner.

New Features:
- Add receiver_id to Message model and include it in normalization
- Implement private message routing by emitting newMessage events to both sender and recipient sockets
- Filter client-side message list to display only conversations between the current user and the selected partner

Enhancements:
- Standardize userId assignment in socketAuthMiddleware to use token sub as primary identifier
- Introduce userSocketMap to track active user sockets and handle disconnect cleanup
- Unify sender ID lookup in normalizeMessage by handling both sender_id and sender fields
- Improve sender lookup in MessageList with case-insensitive ID fallback
- Simplify user fetching on the client by removing self-filtering from the users list
- Clear messages state on client when authentication is lost or socket disconnects